### PR TITLE
feat(PA-135): add categories placeholder, highlight of menu items etc

### DIFF
--- a/src/components/Categories/Categories.tsx
+++ b/src/components/Categories/Categories.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect } from "react";
+import { Typography } from "@mui/material";
+import Navbar from "../Navigation/Navigation";
+
+const Categories: React.FC = () => {
+  useEffect(() => {
+    document.title = "eCommerce | Categories";
+  });
+
+  return (
+    <div>
+      <Navbar />
+      <Typography variant="h1">Categories</Typography>
+    </div>
+  );
+};
+
+export default Categories;

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -12,7 +12,7 @@ import {
   Paper,
 } from "@mui/material";
 
-import { Link as RouterLink } from "react-router-dom";
+import { Link as RouterLink, useLocation } from "react-router-dom";
 
 import { grey } from "@mui/material/colors";
 
@@ -21,7 +21,7 @@ import { grey } from "@mui/material/colors";
 const menus = [
   { name: "Home", route: "/" },
   { name: "Products", route: "/products" },
-  { name: "Categories", route: "/" },
+  { name: "Categories", route: "/categories" },
   { name: "About", route: "/about" },
 ];
 
@@ -43,16 +43,9 @@ const TitleStyling = {
   },
 };
 
-// Navigation Buttons
-const ButtonStyling = {
-  color: grey[900],
-  "&:hover": {
-    backgroundColor: "none",
-  },
-};
-
 const Navbar: React.FC = () => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const location = useLocation();
 
   // basically anchor is HTML element where mouse click happened
   const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
@@ -99,7 +92,19 @@ const Navbar: React.FC = () => {
                     component={RouterLink}
                     variant="body1"
                     to={menuItem.route}
-                    sx={{ color: grey[900] }}
+                    sx={{
+                      color:
+                        location.pathname === menuItem.route
+                          ? grey[900]
+                          : grey[600],
+                      fontWeight:
+                        location.pathname === menuItem.route
+                          ? "bold"
+                          : "normal",
+                      "&:hover": {
+                        color: "inherit",
+                      },
+                    }}
                   >
                     {menuItem.name}
                   </Typography>
@@ -116,10 +121,16 @@ const Navbar: React.FC = () => {
               alignItems: "center",
             }}
           >
-            <IconButton disableRipple>
+            <IconButton component={RouterLink} to={"/"} disableRipple>
               <KeyboardCommandKey sx={{ ...LogoStyle }} />
             </IconButton>
-            <Typography variant="h1" noWrap sx={{ ...TitleStyling }}>
+            <Typography
+              variant="h1"
+              component={RouterLink}
+              to={"/"}
+              noWrap
+              sx={{ ...TitleStyling }}
+            >
               BDNX
             </Typography>
           </Box>
@@ -137,7 +148,17 @@ const Navbar: React.FC = () => {
                 key={menuItem.name}
                 component={RouterLink}
                 to={menuItem.route}
-                sx={{ ...ButtonStyling }}
+                sx={{
+                  color:
+                    location.pathname === menuItem.route
+                      ? grey[900]
+                      : grey[600],
+                  fontWeight:
+                    location.pathname === menuItem.route ? "bold" : "normal",
+                  "&:hover": {
+                    backgroundColor: "inherit",
+                  },
+                }}
                 disableTouchRipple
               >
                 <Typography

--- a/src/components/Product/Products.tsx
+++ b/src/components/Product/Products.tsx
@@ -1,7 +1,14 @@
 // A Products page component that displays the list of products
 import { Link } from "react-router-dom";
-import { useEffect, useState } from "react"; 
-import { Box, Typography, Breadcrumbs, Container, Grid, Paper } from "@mui/material";
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Typography,
+  Breadcrumbs,
+  Container,
+  Grid,
+  Paper,
+} from "@mui/material";
 
 import { ProductService } from "@/services/product-service";
 
@@ -11,11 +18,12 @@ import { ProductModel } from "@/domain/models/ProductModel";
 import Paginator from "@/components/Pagination/Paginator";
 import ProductCard from "../ProductCard/ProductCard";
 import Footer from "../Footer/Footer";
+import Navbar from "../Navigation/Navigation";
 
 export default function Products() {
   const [products, setProducts] = useState<PagedList<ProductModel>>();
   const [currentPage, setCurrentPage] = useState(1);
-  
+
   /**
    * A useEffect required to get product data upon mount.
    */
@@ -37,112 +45,149 @@ export default function Products() {
 
   return (
     <>
-    <Box
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        minHeight: "100vh",
-      }}
-    >   
-      <Box component="main" sx={{ flexGrow: 1 }}>
-        <Container maxWidth="xl" sx={{ mt: 4, mb: 8 }}>
-          {/* REPLACE: breadcrumb currently hardcoded. needs to be dynamic */}
-          <Breadcrumbs>
-            <Link to="/">Home</Link>
-            <Link to="/products">Products</Link>
-          </Breadcrumbs>
+      <Navbar />
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          minHeight: "100vh",
+        }}
+      >
+        <Box component="main" sx={{ flexGrow: 1 }}>
+          <Container maxWidth="xl" sx={{ mt: 4, mb: 8 }}>
+            {/* REPLACE: breadcrumb currently hardcoded. needs to be dynamic */}
+            <Breadcrumbs>
+              <Link to="/">Home</Link>
+              <Link to="/products">Products</Link>
+            </Breadcrumbs>
 
-          {/* Responsive Flex Container */}
-          <Box 
-            sx={{ 
-              display: "flex", 
-              flexDirection: { xs: "column", md: "row" }, 
-              gap: 3, 
-              mt: 2.5 
-            }}
-          >
-            {/* Filters section */}
-            <Box 
-              sx={{ 
-                width: { xs: "100%", md: "240px" }, 
-                flexShrink: 0 
+            {/* Responsive Flex Container */}
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: { xs: "column", md: "row" },
+                gap: 3,
+                mt: 2.5,
               }}
             >
-              {/* Categories filter would be implemented here */}
-              <Paper elevation={0} sx={{ p: 2, border: "1px solid #e0e0e0", borderRadius: 3 }}>
-                <Typography variant="h6" sx={{ mb: 2 }}>Filters</Typography>
-                <Box sx={{ mb: 3 }}>
-                  <Typography variant="subtitle1" sx={{ mb: 1 }}>Categories</Typography>
-                  <Typography variant="subtitle1" sx={{ mb: 1 }}>Category 1</Typography>
-                  <Typography variant="subtitle1" sx={{ mb: 1 }}>Category 2</Typography>
-                  <Typography variant="subtitle1" sx={{ mb: 1 }}>Category 3</Typography>
-                  <Typography variant="subtitle1" sx={{ mb: 1 }}>Category 4</Typography>
-                  <Typography variant="subtitle1" sx={{ mb: 1 }}>Category 5</Typography>
-                  <Typography variant="subtitle1" sx={{ mb: 1 }}>Category 6</Typography>
-                </Box>
-
-                <Box sx={{ mb: 3 }}>
-                  {/* Price range filter would be implemented here */}
-                </Box>
-              </Paper>
-            </Box>
-
-            {/* Product listing */}
-            <Box sx={{ flex: 1 }}>
-              <Box 
-                sx={{ 
-                  display: "flex", 
-                  flexDirection: { xs: "column", sm: "row" }, 
-                  justifyContent: "space-between", 
-                  alignItems: { xs: "flex-start", sm: "center" }, 
-                  mb: 2.5 
+              {/* Filters section */}
+              <Box
+                sx={{
+                  width: { xs: "100%", md: "240px" },
+                  flexShrink: 0,
                 }}
               >
-                {products && (
-                  <Typography variant="body2" color="text.secondary">
-                    Showing {products.results.length} products
+                {/* Categories filter would be implemented here */}
+                <Paper
+                  elevation={0}
+                  sx={{ p: 2, border: "1px solid #e0e0e0", borderRadius: 3 }}
+                >
+                  <Typography variant="h6" sx={{ mb: 2 }}>
+                    Filters
                   </Typography>
-                )}
+                  <Box sx={{ mb: 3 }}>
+                    <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                      Categories
+                    </Typography>
+                    <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                      Category 1
+                    </Typography>
+                    <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                      Category 2
+                    </Typography>
+                    <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                      Category 3
+                    </Typography>
+                    <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                      Category 4
+                    </Typography>
+                    <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                      Category 5
+                    </Typography>
+                    <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                      Category 6
+                    </Typography>
+                  </Box>
 
-                <Box sx={{ display: "flex", alignItems: "center", mt: { xs: 1, sm: 0 } }}>
-                  <Typography variant="body2" sx={{ mr: 1 }} color="text.primary">Sort by:</Typography>
-                  {/* Sort options to be implemented */}
-                </Box>
+                  <Box sx={{ mb: 3 }}>
+                    {/* Price range filter would be implemented here */}
+                  </Box>
+                </Paper>
               </Box>
 
-              <Grid container spacing={3}>
-                {products?.results.map((product) => (
-                  <Grid size={{xs:12, sm:6, md:4, lg:3}} key={product.id}>
-                    <Box sx={{ 
+              {/* Product listing */}
+              <Box sx={{ flex: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: { xs: "column", sm: "row" },
+                    justifyContent: "space-between",
+                    alignItems: { xs: "flex-start", sm: "center" },
+                    mb: 2.5,
+                  }}
+                >
+                  {products && (
+                    <Typography variant="body2" color="text.secondary">
+                      Showing {products.results.length} products
+                    </Typography>
+                  )}
+
+                  <Box
+                    sx={{
                       display: "flex",
-                      justifyContent: "center"
-                    }}>
-                      <ProductCard 
-                        product={product}
-                        width="100%"
-                        height="100%"
-                      />
-                    </Box>
-                  </Grid>
-                ))}
-              </Grid>
+                      alignItems: "center",
+                      mt: { xs: 1, sm: 0 },
+                    }}
+                  >
+                    <Typography
+                      variant="body2"
+                      sx={{ mr: 1 }}
+                      color="text.primary"
+                    >
+                      Sort by:
+                    </Typography>
+                    {/* Sort options to be implemented */}
+                  </Box>
+                </Box>
+
+                <Grid container spacing={3}>
+                  {products?.results.map((product) => (
+                    <Grid
+                      size={{ xs: 12, sm: 6, md: 4, lg: 3 }}
+                      key={product.id}
+                    >
+                      <Box
+                        sx={{
+                          display: "flex",
+                          justifyContent: "center",
+                        }}
+                      >
+                        <ProductCard
+                          product={product}
+                          width="100%"
+                          height="100%"
+                        />
+                      </Box>
+                    </Grid>
+                  ))}
+                </Grid>
+              </Box>
             </Box>
-          </Box>
-          
-          {/* Pagination component */}
-          <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
-            <Paginator
-              pagedData={products}
-              currentPage={currentPage}
-              onPageChange={handlePageChange}
-            />
-          </Box>
-        </Container>
+
+            {/* Pagination component */}
+            <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+              <Paginator
+                pagedData={products}
+                currentPage={currentPage}
+                onPageChange={handlePageChange}
+              />
+            </Box>
+          </Container>
+        </Box>
+
+        {/* Footer Section */}
+        <Footer />
       </Box>
-      
-      {/* Footer Section */}
-      <Footer />
-    </Box>
     </>
   );
-};
+}

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -6,38 +6,43 @@ import About from "@/components/About/About";
 import Profile from "@/components/Profile/Profile";
 import Products from "@/components/Product/Products";
 import ProductDetails from "@/components/Product/ProductDetails";
+import Categories from "@/components/Categories/Categories";
 import NotFound from "@/components/NotFound/NotFound";
 
 export const router = createBrowserRouter([
-    {
+  {
+    path: "/",
+    element: <App />,
+    children: [
+      {
+        index: true,
         path: "/",
-        element: <App />,
-        children: [
-            {
-                index: true,
-                path: "/",
-                element: <Home />
-            },
-            {
-                path: "/about",
-                element: <About />
-            },
-            {
-                path: "/profile",
-                element: <Profile />
-            },
-            {
-              path: "/products",
-              element: <Products />
-            },
-            {
-              path: "products/:id/details",
-              element: <ProductDetails />
-            },
-            {
-                path: "/*",
-                element: <NotFound />
-            }
-        ]
-    },
+        element: <Home />,
+      },
+      {
+        path: "/about",
+        element: <About />,
+      },
+      {
+        path: "/profile",
+        element: <Profile />,
+      },
+      {
+        path: "/products",
+        element: <Products />,
+      },
+      {
+        path: "products/:id/details",
+        element: <ProductDetails />,
+      },
+      {
+        path: "categories",
+        element: <Categories />,
+      },
+      {
+        path: "/*",
+        element: <NotFound />,
+      },
+    ],
+  },
 ]);


### PR DESCRIPTION
PR adds highlighting of menu items (in both desktop and mobile screens) to show which page user has navigated to.

Also makes navigation company logo and title **clickable** to route to home page.

![image](https://github.com/user-attachments/assets/741d58f6-8d1e-4508-8855-eae627c2ecb8)

![image](https://github.com/user-attachments/assets/bb783002-f4e7-4091-9591-757df65ad867)
