### PR TITLE
Pa227 Update Stripe to use order entity

### DIFF
--- a/src/domain/models/OrderModel.ts
+++ b/src/domain/models/OrderModel.ts
@@ -1,0 +1,55 @@
+import { ProductItemModel } from "./ProductItemModel";
+import { UserModel } from "./UserModel";
+
+export interface OrderItemModel {
+  readonly id: string;
+  productItem: ProductItemModel;
+  quantity: number;
+  price: number;
+}
+
+export interface AddressModel {
+  addressLine: string;
+  city: string;
+  postcode: string;
+  state: string;
+  country: string;
+}
+
+export interface ShippingVendorModel {
+  readonly id: number;
+  name: string;
+  logoUrl: string;
+  isActive: boolean;
+}
+
+export interface GuestUserModel {
+  readonly id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  phone?: string;
+}
+
+export interface OrderModel {
+  readonly id: string;
+  createdAt: string;
+  totalPrice: number;
+  status: string;
+  items: OrderItemModel[];
+  user?: UserModel;
+  guestUser?: GuestUserModel;
+}
+
+export type PaymentStatus = "pending" | "paid" | "failed";
+
+export interface OrderStatusModel {
+  status: PaymentStatus;
+  orderId?: string;
+  amount?: number;
+  currency?: string;
+  reason?: string;
+  order?: OrderModel;
+  address?: AddressModel;
+  shippingVendor?: ShippingVendorModel;
+}

--- a/src/resources/components/OrderSummary/OrderSummary.tsx
+++ b/src/resources/components/OrderSummary/OrderSummary.tsx
@@ -190,6 +190,7 @@ const OrderSummary: React.FC<ProductCardProps> = ({ cartState }) => {
         <Button
           variant="contained"
           color="primary"
+          disabled={cartState.length === 0}
           sx={{
             width: "100%",
             alignSelf: "center",

--- a/src/resources/pages/Checkout/OrderComplete.tsx
+++ b/src/resources/pages/Checkout/OrderComplete.tsx
@@ -9,24 +9,24 @@ import {
   Stack,
   Divider,
   CircularProgress,
+  Card,
+  CardContent,
+  Grid,
+  Avatar,
 } from "@mui/material";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import LocalShippingIcon from "@mui/icons-material/LocalShipping";
 import api from "@/api";
-
-type Status = "pending" | "paid" | "failed";
-type OrderStatus = {
-  status: Status;
-  orderId?: number;
-  amount?: number;
-  currency?: string;
-  reason?: string;
-};
+import { OrderStatusModel } from "@/domain/models/OrderModel";
+import { cartState } from "@/domain/state";
 
 export default function OrderComplete() {
   const params = new URLSearchParams(window.location.search);
   const pi = params.get("pi") || params.get("payment_intent") || "";
-  const [data, setData] = useState<OrderStatus>({ status: "pending" });
+  const [data, setData] = useState<OrderStatusModel>({ status: "pending" });
+  const clearCart = cartState((state) => state.clearCart);
+  const [cartCleared, setCartCleared] = useState(false);
 
   useEffect(() => {
     if (!pi) return;
@@ -48,6 +48,13 @@ export default function OrderComplete() {
           if (res.status >= 200 && res.status < 300) {
             const j = res.data;
             setData(j);
+            
+            // Clear cart when payment is successful and we haven't cleared it yet
+            if (j.status === "paid" && !cartCleared) {
+              clearCart();
+              setCartCleared(true);
+            }
+            
             if (j.status === "paid" || j.status === "failed") return;
           }
         } catch (_) {
@@ -85,6 +92,106 @@ export default function OrderComplete() {
       </Box>
     </Container>
   );
+  {/* Order Summary */}
+  const OrderSummary: React.FC<{ data: OrderStatusModel }> = ({ data }) => {
+    if (!data.order || !data.address || !data.shippingVendor) return null;
+
+    const { order, address, shippingVendor } = data;
+    const customerName = order.user 
+      ? `${order.user.firstName} ${order.user.lastName}`
+      : order.guestUser 
+      ? `${order.guestUser.firstName} ${order.guestUser.lastName}`
+      : "Customer";
+
+    return (
+      <Box sx={{ mt: 3, textAlign: "left" }}>
+        <Divider sx={{ mb: 3 }} />
+        
+        {/* Order Items */}
+        <Typography variant="h6" gutterBottom>
+          Order Items
+        </Typography>
+        <Stack spacing={2} sx={{ mb: 3 }}>
+          {order.items.map((item) => (
+            <Card key={item.id} variant="outlined">
+              <CardContent sx={{ p: 2, "&:last-child": { pb: 2 } }}>
+                <Grid container spacing={2} alignItems="center">
+                  <Grid size={{xs:"auto"}}>
+                    {item.productItem.imageUrls && Array.isArray(item.productItem.imageUrls) && item.productItem.imageUrls.length > 0 ? (
+                      <Avatar
+                        src={item.productItem.imageUrls[0]}
+                        sx={{ width: 60, height: 60 }}
+                        variant="rounded"
+                      />
+                    ) : (
+                      <Avatar sx={{ width: 60, height: 60 }} variant="rounded">
+                        {item.productItem.product.name[0]}
+                      </Avatar>
+                    )}
+                  </Grid>
+                  <Grid size={{xs:"auto"}}>
+                    <Typography variant="body1" fontWeight="medium">
+                      {item.productItem.product.name}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      SKU: {item.productItem.sku}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      Quantity: {item.quantity}
+                    </Typography>
+                  </Grid>
+                  <Grid size={{xs:"auto"}}>
+                    <Typography variant="body1" fontWeight="medium">
+                      ${(item.price * item.quantity).toFixed(2)}
+                    </Typography>
+                  </Grid>
+                </Grid>
+              </CardContent>
+            </Card>
+          ))}
+        </Stack>
+
+        {/* Shipping Info */}
+        <Typography variant="h6" gutterBottom>
+          Shipping Details
+        </Typography>
+        <Card variant="outlined" sx={{ mb: 3 }}>
+          <CardContent sx={{ p: 2, "&:last-child": { pb: 2 } }}>
+            <Stack spacing={1}>
+              <Box display="flex" alignItems="center" gap={1}>
+                <LocalShippingIcon color="primary" fontSize="small" />
+                <Typography variant="body1" fontWeight="medium">
+                  {shippingVendor.name}
+                </Typography>
+              </Box>
+              <Typography variant="body2" color="text.secondary">
+                {customerName}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {address.addressLine}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {address.city}, {address.state} {address.postcode}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {address.country}
+              </Typography>
+            </Stack>
+          </CardContent>
+        </Card>
+
+        {/* Order Total */}
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          <Typography variant="h6">
+            Total
+          </Typography>
+          <Typography variant="h6" fontWeight="bold">
+            ${order.totalPrice.toFixed(2)} {data.currency?.toUpperCase()}
+          </Typography>
+        </Box>
+      </Box>
+    );
+  };
 
   if (!pi) {
     return (
@@ -157,12 +264,17 @@ export default function OrderComplete() {
         <Typography variant="h4" fontWeight={800}>
           Order complete!
         </Typography>
-        {typeof data.amount === "number" && data.currency ? (
+        {data.order ? (
+          <Typography variant="body1" color="text.secondary">
+            Order <strong>#{data.order.id.slice(-8)}</strong> has been confirmed.
+          </Typography>
+        ) : typeof data.amount === "number" && data.currency ? (
           <Typography variant="body1" color="text.secondary">
             Charged <strong>{(data.amount / 100).toFixed(2)}</strong>{" "}
             <strong>{data.currency.toUpperCase()}</strong>.
           </Typography>
         ) : null}
+        <OrderSummary data={data} />
         <Divider sx={{ width: "100%", my: 2 }} />
         <Button onClick={handleContinueShopping} variant="contained" size="large">
           Continue Shopping

--- a/src/resources/pages/Checkout/OrderComplete.tsx
+++ b/src/resources/pages/Checkout/OrderComplete.tsx
@@ -79,7 +79,7 @@ export default function OrderComplete() {
 
   const Shell: React.FC<{ children: React.ReactNode }> = ({ children }) => (
     <Container maxWidth="sm">
-      <Box minHeight="80vh" display="flex" alignItems="center" justifyContent="center">
+      <Box minHeight="80vh" display="flex" alignItems="center" justifyContent="center" pt={4}>
         <Paper
           elevation={4}
           sx={{

--- a/src/resources/pages/Checkout/OrderComplete.tsx
+++ b/src/resources/pages/Checkout/OrderComplete.tsx
@@ -52,6 +52,8 @@ export default function OrderComplete() {
             // Clear cart when payment is successful and we haven't cleared it yet
             if (j.status === "paid" && !cartCleared) {
               clearCart();
+              // To clear the cart when authed user checks out
+              window.dispatchEvent(new CustomEvent(Constants.EVENT_CART_UPDATED));
               setCartCleared(true);
             }
             
@@ -79,7 +81,7 @@ export default function OrderComplete() {
     <Container maxWidth="sm">
       <Box minHeight="80vh" display="flex" alignItems="center" justifyContent="center">
         <Paper
-          elevation={6}
+          elevation={4}
           sx={{
             p: 4,
             borderRadius: 3,
@@ -132,9 +134,6 @@ export default function OrderComplete() {
                   <Grid size={{xs:"auto"}}>
                     <Typography variant="body1" fontWeight="medium">
                       {item.productItem.product.name}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      SKU: {item.productItem.sku}
                     </Typography>
                     <Typography variant="body2" color="text.secondary">
                       Quantity: {item.quantity}
@@ -193,6 +192,7 @@ export default function OrderComplete() {
     );
   };
 
+  // no payment intent found
   if (!pi) {
     return (
       <Shell>
@@ -211,7 +211,7 @@ export default function OrderComplete() {
       </Shell>
     );
   }
-
+  // while order is pending
   if (data.status === "pending") {
     return (
       <Shell>
@@ -224,14 +224,11 @@ export default function OrderComplete() {
             This usually takes a few seconds. We’ll update automatically.
           </Typography>
           <Divider sx={{ width: "100%", my: 2 }} />
-          <Button onClick={handleContinueShopping} variant="text">
-            Continue Shopping
-          </Button>
         </Stack>
       </Shell>
     );
   }
-
+  // if the payment failed
   if (data.status === "failed") {
     return (
       <Shell>
@@ -267,11 +264,6 @@ export default function OrderComplete() {
         {data.order ? (
           <Typography variant="body1" color="text.secondary">
             Order <strong>#{data.order.id.slice(-8)}</strong> has been confirmed.
-          </Typography>
-        ) : typeof data.amount === "number" && data.currency ? (
-          <Typography variant="body1" color="text.secondary">
-            Charged <strong>{(data.amount / 100).toFixed(2)}</strong>{" "}
-            <strong>{data.currency.toUpperCase()}</strong>.
           </Typography>
         ) : null}
         <OrderSummary data={data} />

--- a/src/resources/pages/Checkout/gateways/Stripe/StripeGateway.tsx
+++ b/src/resources/pages/Checkout/gateways/Stripe/StripeGateway.tsx
@@ -73,7 +73,7 @@ const StripeGateway = () => {
             currency: currency.toLowerCase(),
             country: userLocation ? userLocation.toLowerCase() : undefined,
             cart: cart.map((ci) => ({
-              product: { id: ci.productItem.product.id },
+              product: { id: ci.productItem.id },
               quantity: ci.quantity,
             })),
           },


### PR DESCRIPTION
### Frontend Stripe Update

**Main Changes**

- We are now displaying an order summary once order creation + payment are complete
- User is able to select a shipping vendor during the checkout process. This is saved with the order.
- Users cannot checkout with nothing in their cart

**Screenshots**
Order Summary:
<img width="538" height="764" alt="ordersummary" src="https://github.com/user-attachments/assets/63bc937b-def1-45a2-a3a6-310d62bffc7f" />

Shipping vendor selection:
<img width="492" height="815" alt="Screenshot 2025-09-10 at 2 40 48 pm" src="https://github.com/user-attachments/assets/6871c26b-69b4-40ac-b6a3-c735e6e67ead" />

